### PR TITLE
Filter tracer requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,7 @@ Or install it yourself as:
 
 ## Usage
 
-Set an OpenTracing-compatible tracer, such as ['jaeger-client'](https://github.com/salemove/jaeger-client-ruby), as the global tracer.
-
-Export an environment variable, `TRACER_INGEST_URL`, with the Jaeger span ingest URL. The tracer will ignore outgoing requests to this URL when tracing requests.
-
-```bash
-export TRACER_INGEST_URL='https://localhost:14268/api/traces'
-```
-
-If no URL is specified, the one above is used as the default.
+Set an OpenTracing-compatible tracer, such as ['jaeger-client'](https://github.com/signalfx/jaeger-client-ruby), as the global tracer.
 
 Before making any requests, configure the tracer:
 
@@ -48,7 +40,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/achandras/net-http-tracer.
+Bug reports and pull requests are welcome on GitHub at https://github.com/signalfx/net-http-tracer.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Net::Http::Tracer
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/net/http/tracer`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+This gem automatically traces all requests made with Net::HTTP.
 
 ## Installation
 
@@ -22,7 +20,25 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+Set an OpenTracing-compatible tracer, such as ['jaeger-client'](https://github.com/salemove/jaeger-client-ruby), as the global tracer.
+
+Export an environment variable, `TRACER_INGEST_URL`, with the Jaeger span ingest URL. The tracer will ignore outgoing requests to this URL when tracing requests.
+
+```bash
+export TRACER_INGEST_URL='https://localhost:14268/api/traces'
+```
+
+If no URL is specified, the one above is used as the default.
+
+Before making any requests, configure the tracer:
+
+```ruby
+require 'net/http/tracer'
+
+Net::Http::Tracer.instrument
+```
+
+The spans will be given a name consisting of the HTTP method and request path.
 
 ## Development
 
@@ -32,7 +48,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/net-http-tracer.
+Bug reports and pull requests are welcome on GitHub at https://github.com/achandras/net-http-tracer.
 
 ## License
 

--- a/lib/net/http/tracer.rb
+++ b/lib/net/http/tracer.rb
@@ -37,7 +37,7 @@ module Net
                   "peer.host" => @address,
                   "peer.port" => @port,
                 }
-                OpenTracing.global_tracer.start_active_span("net_http.request", tags: tags) do |scope|
+                OpenTracing.global_tracer.start_active_span(req.path, tags: tags) do |scope|
                   # inject the trace so it's available to the remote service
                   OpenTracing.inject(scope.span.context, OpenTracing::FORMAT_RACK, req)
 

--- a/lib/net/http/tracer.rb
+++ b/lib/net/http/tracer.rb
@@ -1,7 +1,9 @@
 require "net/http/tracer/version"
+require "net/http"
+require "uri"
 
 module Net
-  module HTTP
+  module Http
     module Tracer
 
       class << self
@@ -10,10 +12,10 @@ module Net
 
         def instrument
           begin
-            @tracer_url = URI.parse(ENV['TRACER_INGEST_URL'])
+            @tracer_url = ::URI.parse(ENV['TRACER_INGEST_URL'])
           rescue
             puts "Tracer ingest URL not provided"
-            @tracer_url = URI.new
+            @tracer_url = ::URI.parse("http://localhost:14268/api/traces")
           end
 
           patch_request
@@ -59,9 +61,9 @@ module Net
             # Compare path, address, and port
             def ingest_path?(req)
               
-              return "#{Tracer.tracer_url.path}?#{Tracer.tracer_url.query}" == req.path && # this should short circuit in most cases
-                Tracer.tracer_url.host == @address &&
-                Tracer.tracer_url.port == @port
+              return "#{::Net::Http::Tracer.tracer_url.path}?#{::Net::Http::Tracer.tracer_url.query}" == req.path && # this should short circuit in most cases
+                ::Net::Http::Tracer.tracer_url.host == @address &&
+                ::Net::Http::Tracer.tracer_url.port == @port
             end
           end
         end

--- a/lib/net/http/tracer.rb
+++ b/lib/net/http/tracer.rb
@@ -7,7 +7,11 @@ module Net
 
       class << self
 
-        def instrument
+        attr_accessor :ignore_request
+
+        def instrument(ignore_request: nil)
+          @ignore_request = ignore_request
+
           patch_request
         end
 
@@ -19,8 +23,9 @@ module Net
             def request(req, body = nil, &block)
               res = ''
 
-              if Thread.current.thread_variable_get(:tracer_reporter)
-                # this is from the thread to send spans, so we should ignore it
+              if ::Net::Http::Tracer.ignore_request.respond_to?(:call) &&
+                 ::Net::Http::Tracer.ignore_request.call
+
                 res = request_original(req, body, &block)
               else
                 tags = {

--- a/lib/net/http/tracer.rb
+++ b/lib/net/http/tracer.rb
@@ -36,7 +36,7 @@ module Net
             def request(req, body = nil, &block)
               res = ''
 
-              if ingest_path?(req)
+              if req.key? 'opentracing-ignore'
                 # this is probably a request to export spans, so we should ignore it
                 res = request_original(req, body, &block)
               else
@@ -62,15 +62,6 @@ module Net
               end
 
               res
-            end
-
-            # Make a best effort to see if this is going out to the ingest url
-            # Compare path, address, and port
-            def ingest_path?(req)
-              
-              return "#{::Net::Http::Tracer.tracer_url.path}?#{::Net::Http::Tracer.tracer_url.query}" == req.path && # this should short circuit in most cases
-                ::Net::Http::Tracer.tracer_url.host == @address &&
-                ::Net::Http::Tracer.tracer_url.port == @port
             end
           end
         end

--- a/lib/net/http/tracer.rb
+++ b/lib/net/http/tracer.rb
@@ -8,12 +8,18 @@ module Net
 
         attr_reader :tracer_url
 
-        def instrument
-          begin
-            @tracer_url = ::URI.parse(ENV['TRACER_INGEST_URL'])
-          rescue
-            puts "Tracer ingest URL not provided"
-            @tracer_url = ::URI.parse("http://localhost:14268/api/traces")
+        def instrument(tracer_url: nil)
+          if tracer_url.nil?
+            # if the tracer url wasn't given, try to fall back to an env var
+            # or a default
+            begin
+              @tracer_url = ::URI.parse(ENV['TRACER_INGEST_URL'])
+            rescue
+              puts "Tracer ingest URL not provided"
+              @tracer_url = ::URI.parse("http://localhost:14268/api/traces")
+            end
+          else
+            @tracer_url = tracer_url
           end
 
           patch_request

--- a/lib/net/http/tracer.rb
+++ b/lib/net/http/tracer.rb
@@ -1,6 +1,4 @@
 require "net/http/tracer/version"
-require "net/http"
-require "uri"
 
 module Net
   module Http

--- a/lib/net/http/tracer.rb
+++ b/lib/net/http/tracer.rb
@@ -9,18 +9,21 @@ module Net
         attr_reader :tracer_url
 
         def instrument(tracer_url: nil)
+          tracer_str = ''
           if tracer_url.nil?
             # if the tracer url wasn't given, try to fall back to an env var
             # or a default
             begin
-              @tracer_url = ::URI.parse(ENV['TRACER_INGEST_URL'])
+              tracer_str = ENV['TRACER_INGEST_URL']
             rescue
               puts "Tracer ingest URL not provided"
-              @tracer_url = ::URI.parse("http://localhost:14268/api/traces")
+              tracer_str = "http://localhost:14268/api/traces"
             end
           else
-            @tracer_url = tracer_url
+            tracer_str = tracer_url
           end
+
+          @tracer_url = URI.parse(tracer_str)
 
           patch_request
         end

--- a/lib/net/http/tracer.rb
+++ b/lib/net/http/tracer.rb
@@ -37,7 +37,7 @@ module Net
                   "peer.host" => @address,
                   "peer.port" => @port,
                 }
-                OpenTracing.global_tracer.start_active_span("#{req.method} #{req.path}", tags: tags) do |scope|
+                OpenTracing.global_tracer.start_active_span("net_http.request", tags: tags) do |scope|
                   # inject the trace so it's available to the remote service
                   OpenTracing.inject(scope.span.context, OpenTracing::FORMAT_RACK, req)
 

--- a/lib/net/http/tracer.rb
+++ b/lib/net/http/tracer.rb
@@ -6,25 +6,7 @@ module Net
 
       class << self
 
-        attr_reader :tracer_url
-
-        def instrument(tracer_url: nil)
-          tracer_str = ''
-          if tracer_url.nil?
-            # if the tracer url wasn't given, try to fall back to an env var
-            # or a default
-            begin
-              tracer_str = ENV['TRACER_INGEST_URL']
-            rescue
-              puts "Tracer ingest URL not provided"
-              tracer_str = "http://localhost:14268/api/traces"
-            end
-          else
-            tracer_str = tracer_url
-          end
-
-          @tracer_url = URI.parse(tracer_str)
-
+        def instrument
           patch_request
         end
 

--- a/lib/net/http/tracer.rb
+++ b/lib/net/http/tracer.rb
@@ -10,6 +10,13 @@ module Net
           patch_request
         end
 
+        def tracer_request?
+          for location in caller_locations
+            return true if location.label == 'send_spans'
+          end
+          return false
+        end
+
         def patch_request
 
           ::Net::HTTP.module_eval do
@@ -18,7 +25,7 @@ module Net
             def request(req, body = nil, &block)
               res = ''
 
-              if req.key? 'opentracing-ignore'
+              if ::Net::Http::Tracer.tracer_request?
                 # this is probably a request to export spans, so we should ignore it
                 res = request_original(req, body, &block)
               else

--- a/lib/net/http/tracer.rb
+++ b/lib/net/http/tracer.rb
@@ -36,7 +36,7 @@ module Net
                   "peer.host" => @address,
                   "peer.port" => @port,
                 }
-                OpenTracing.global_tracer.start_active_span(req.path, tags: tags) do |scope|
+                OpenTracing.global_tracer.start_active_span("net_http.request", tags: tags) do |scope|
                   # inject the trace so it's available to the remote service
                   OpenTracing.inject(scope.span.context, OpenTracing::FORMAT_RACK, req)
 

--- a/net-http-tracer.gemspec
+++ b/net-http-tracer.gemspec
@@ -34,5 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "opentracing_test_tracer", "~> 0.1"
+  spec.add_development_dependency "webmock", "~> 3.4.2"
 
 end

--- a/net-http-tracer.gemspec
+++ b/net-http-tracer.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency "opentracing", "~> 0.4.2"
+  # spec.add_dependency "opentracing", "~> 0.4.2"
 end

--- a/net-http-tracer.gemspec
+++ b/net-http-tracer.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["achandrasekar@signalfx.com"]
 
   spec.summary       = %q{Tracer for Net::HTTP requests.}
-  spec.homepage      = "http://github.com/achandras/net-http-tracer"
+  spec.homepage      = "http://github.com/signalfx/net-http-tracer"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
@@ -35,5 +35,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  # spec.add_dependency "opentracing", "~> 0.4.2"
 end

--- a/spec/net-http/tracer_spec.rb
+++ b/spec/net-http/tracer_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+require 'net/http/tracer'
+
+RSpec.describe Net::Http::Tracer do
+  describe "Class Methods" do
+    it { should respond_to :instrument }
+    it { should respond_to :patch_request }
+  end
+
+  # @mock_httpdd = mock("http")
+
+end

--- a/spec/net-http/tracer_spec.rb
+++ b/spec/net-http/tracer_spec.rb
@@ -7,6 +7,44 @@ RSpec.describe Net::Http::Tracer do
     it { should respond_to :patch_request }
   end
 
-  # @mock_httpdd = mock("http")
+  describe "tracing requests" do
 
+    before(:context) do
+      OpenTracing.global_tracer = OpenTracingTestTracer.build
+
+      Net::Http::Tracer.instrument
+    end
+
+    after(:example) do
+      OpenTracing.global_tracer.spans.clear
+    end
+
+    it "adds spans for GET" do
+      stub_request(:any, "www.example.com")
+      Net::HTTP.get("www.example.com", "/")
+
+      expect(OpenTracing.global_tracer.spans.count).to be > 0
+    end
+
+    it "adds spans for POST" do
+      stub_request(:any, "www.example.com")
+      Net::HTTP.get("www.example.com", "/")
+
+      expect(OpenTracing.global_tracer.spans.count).to be > 0
+    end
+
+    it "adds spans for PUT" do
+      stub_request(:any, "www.example.com")
+      Net::HTTP.get("www.example.com", "/")
+
+      expect(OpenTracing.global_tracer.spans.count).to be > 0
+    end
+
+    it "adds spans for DELETE" do
+      stub_request(:any, "www.example.com")
+      Net::HTTP.get("www.example.com", "/")
+
+      expect(OpenTracing.global_tracer.spans.count).to be > 0
+    end
+  end
 end

--- a/spec/net-http/tracer_spec.rb
+++ b/spec/net-http/tracer_spec.rb
@@ -19,30 +19,30 @@ RSpec.describe Net::Http::Tracer do
       OpenTracing.global_tracer.spans.clear
     end
 
-    it "adds spans for GET" do
+    it "adds spans for GET using a direct method" do
       stub_request(:any, "www.example.com")
       Net::HTTP.get("www.example.com", "/")
 
       expect(OpenTracing.global_tracer.spans.count).to be > 0
     end
 
-    it "adds spans for POST" do
+    it "adds spans for POST with URI" do
       stub_request(:any, "www.example.com")
-      Net::HTTP.get("www.example.com", "/")
+      uri = URI("http://www.example.com/")
+      Net::HTTP.post_form(uri, 'q' => 'test')
 
       expect(OpenTracing.global_tracer.spans.count).to be > 0
     end
 
-    it "adds spans for PUT" do
+    it "adds spans for PUT in block style" do
       stub_request(:any, "www.example.com")
-      Net::HTTP.get("www.example.com", "/")
+      uri = URI("http://www.example.com/")
 
-      expect(OpenTracing.global_tracer.spans.count).to be > 0
-    end
+      Net::HTTP.start(uri.host, uri.port) do |http|
+        request = Net::HTTP::Put.new uri
 
-    it "adds spans for DELETE" do
-      stub_request(:any, "www.example.com")
-      Net::HTTP.get("www.example.com", "/")
+        response = http.request request
+      end
 
       expect(OpenTracing.global_tracer.spans.count).to be > 0
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'bundler/setup'
 require 'net/http/tracer'
 require 'opentracing_test_tracer'
+require 'webmock/rspec'
 
 RSpec.configure do |config|
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,10 @@
+require 'bundler/setup'
+require 'net/http/tracer'
+require 'opentracing_test_tracer'
+
+RSpec.configure do |config|
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
This wasn't the cleanest set of commits.

The `request` method is patched to allow tracing. The patched `request` checks whether the outgoing request is to the given tracer url. If not, a span is started to wrap the call to the unpatched `request`. Otherwise, no span is started, and the unpatched `request` is called.